### PR TITLE
Fixes for latest gcc-13 and stdc++17

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -40,7 +40,7 @@
         "cflags_cc!": ["-fno-rtti", "-fno-exceptions"],
         "cflags_cc+": [
           "-fexceptions",
-          "-std=c++0x",
+          "-std=c++17",
           "-frtti"
         ]
       }],["OS=='mac'", {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "@aspectron/process-list",
-  "version": "2.0.1",
+  "name": "@karlsen/process-list",
+  "version": "2.0.2",
   "description": "Cross-platform method to receive the list of the launched processes",
   "main": "index.js",
   "scripts": {
     "test": "ava test/*.js && prebuild-ci",
-    "install": "prebuild-install || node-gyp configure && node-gyp rebuild"
+    "install": "prebuild-install || node-gyp rebuild"
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/reklatsmasters/node-process-list.git"
+    "url": "git://github.com/karlsen-network/node-process-list.git"
   },
   "bugs": {
-    "url": "https://github.com/reklatsmasters/node-process-list/issues"
+    "url": "https://github.com/karlsen-network/node-process-list/issues"
   },
   "license": "MIT",
   "engines": {
@@ -37,15 +37,20 @@
     "email": "me@reklatsmasters.com"
   },
   "devDependencies": {
-    "ava": "^0.25.0",
-    "prebuild": "^9.1.1",
-    "prebuild-ci": "^3.1.0"
+    "ava": "^6.0.1",
+    "prebuild": "^12.1.0",
+    "prebuild-ci": "^4.0.0"
   },
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.14.0",
-    "pify": "^3.0.0",
-    "prebuild-install": "^5.3.2"
+    "nan": "^2.18.0",
+    "pify": "^6.1.0",
+    "prebuild-install": "^7.1.1"
   },
-  "gypfile": true
+  "gypfile": true,
+  "overrides": {
+    "node-ninja": {
+      "tar": "4.4.18"
+    }
+  }
 }

--- a/src/tasklist.h
+++ b/src/tasklist.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <stdexcept>
 
 #define NORMAL(x, low, high) (((x) > (high))?(high):(((x) < (low))?(low):(x)))
 


### PR DESCRIPTION
Original version is highly outdated and cannot be used on modern Linux environments anymore for compilation of Karlsen Desktop. Noticeable changes:

* Fixed `error: ‘remove_cv_t’ is not a member of ‘std’; did you mean ‘remove_cv’` fixed with switching to std:c++17 standard.
* Added ISO C++ 19.1 exception class <stdexcept> to support latest g++ on modern Linux distributions.
* Updated dependencies to support latest `node`, `npm` and `node-gyp`.
* Updated GitHub URLs